### PR TITLE
Added .rm_prefix

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'devel', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
-          - { os: macOS-latest, r: 'devel', bioc: 'devel'}
-          - { os: windows-latest, r: 'devel', bioc: 'devel'}
+          - { os: ubuntu-latest, r: '4.3', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
+          - { os: macOS-latest, r: '4.3', bioc: 'devel'}
+          - { os: windows-latest, r: '4.3', bioc: 'devel'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/man/plot_community.Rd
+++ b/man/plot_community.Rd
@@ -13,6 +13,7 @@ plot_community(
     "edge_betweenness", "fast_greedy", "label_prop", "leiden"),
   foldGSname = TRUE,
   foldafter = 2,
+  labelFun = .rm_prefix,
   layout = c("fr", "dh", "gem", "graphopt", "kk", "lgl", "mds", "sugiyama"),
   markCommunity = "ellipse",
   markAlpha = 0.2,
@@ -53,6 +54,9 @@ lines}
 
 \item{foldafter}{The number of words after which gene-set names should be
 folded. Defaults to 2}
+
+\item{labelFun}{function to manipulate or modify gene-set labels. By default,
+any database will be stripped from the prefix using a regex pattern}
 
 \item{layout}{The layout algorithm to apply. Accepted layouts are
 \verb{"fr", "dh", "gem", "graphopt", "kk", "lgl", "mds" and "sugiyama"}}

--- a/man/plot_gs2gene.Rd
+++ b/man/plot_gs2gene.Rd
@@ -12,6 +12,7 @@ plot_gs2gene(
   colorGsBy = NULL,
   foldGSname = TRUE,
   foldafter = 2,
+  labelFun = .rm_prefix,
   filterGeneBy = 2,
   layout = c("fr", "dh", "gem", "graphopt", "kk", "lgl", "mds", "sugiyama"),
   edgeColor = "darkgrey",
@@ -56,6 +57,9 @@ lines}
 
 \item{foldafter}{The number of words after which gene-set names should be
 folded.}
+
+\item{labelFun}{function to manipulate or modify gene-set labels. By default,
+any database will be stripped from the prefix using a regex pattern}
 
 \item{filterGeneBy}{Filtration cut-off applied to genes' connectivity (ie.
 how many pathways was a gene involved in).}

--- a/man/plot_gs_network.Rd
+++ b/man/plot_gs_network.Rd
@@ -10,6 +10,7 @@ plot_gs_network(
   colorBy = NULL,
   foldGSname = TRUE,
   foldafter = 2,
+  labelFun = .rm_prefix,
   layout = c("fr", "dh", "gem", "graphopt", "kk", "lgl", "mds", "sugiyama"),
   edgeAlpha = 0.8,
   edgeWidthScale = c(0.5, 3),
@@ -41,6 +42,9 @@ lines}
 
 \item{foldafter}{The number of words after which gene-set names should be
 folded. Defaults to 2}
+
+\item{labelFun}{function to manipulate or modify gene-set labels. By default,
+any database will be stripped from the prefix using a regex pattern}
 
 \item{layout}{The layout algorithm to apply. Accept all layout supported by
 \code{igraph}}

--- a/tests/testthat/test-plot_GSnetwork.R
+++ b/tests/testthat/test-plot_GSnetwork.R
@@ -8,8 +8,8 @@ Scores <- data.frame(
 Scores <- dplyr::mutate(Scores, color_Z = ifelse(robustZ < 0, "Inhibited", "Activated"))
 Scores <- dplyr::mutate(Scores, gs_name = paste("kegg.", gs_name, sep = ""))
 GS <- Scores$gs_name
-g_Zscore <- .make_gsNetwork(Scores, gsTopology, colorBy = "robustZ", plotIsolated = TRUE)
-g_pvalue <- .make_gsNetwork(Scores, gsTopology, colorBy = "pvalue", plotIsolated = TRUE)
+g_Zscore <- .make_gsNetwork(Scores, gsTopology, colorBy = "robustZ", plotIsolated = TRUE, labelFun = NULL)
+g_pvalue <- .make_gsNetwork(Scores, gsTopology, colorBy = "pvalue", plotIsolated = TRUE, labelFun = NULL)
 entrez2name_dir <- system.file("extdata", "entrez2name.rda", package = "sSNAPPY")
 load(entrez2name_dir)
 
@@ -27,8 +27,8 @@ test_that("make_gsNetwork produces the expected outcome",{
     expect_true(is.numeric(igraph::V(g_pvalue)$color))
     # expect_equal(stringr::str_subset(V(g_Zscore)$name, "Histidine"), "Histidine metabolism")
     # expect_equal(stringr::str_subset(V(g_Zscore)$name, "Ascorbate"), "Ascorbate and\naldarate metabolism")
-    g_Zscore_n3 <- .make_gsNetwork(Scores, gsTopology, colorBy = "robustZ",  plotIsolated = TRUE)
-    # expect_equal(stringr::str_subset(V(g_Zscore_n3)$name, "Ascorbate"), "Ascorbate and aldarate metabolism")
+    g_Zscore_n3 <- .make_gsNetwork(Scores, gsTopology, colorBy = "robustZ", plotIsolated = TRUE, labelFun = .rm_prefix)
+    expect_equal(stringr::str_subset(V(g_Zscore_n3)$name, "Ascorbate"), "Ascorbate and aldarate metabolism")
 })
 
 test_that("plot_gs_network returns error when expected", {

--- a/tests/testthat/test-plot_community.R
+++ b/tests/testthat/test-plot_community.R
@@ -8,8 +8,8 @@ Scores <- data.frame(
     mutate(color_Z = ifelse(robustZ < 0, "Inhibited", "Activated"))
 Scores <- dplyr::mutate(Scores, gs_name = paste("kegg.", gs_name, sep = ""))
 GS <- Scores$gs_name
-g_Zscore <- .make_gsNetwork(Scores, gsTopology, colorBy = "robustZ", plotIsolated = TRUE)
-g_pvalue <- .make_gsNetwork(Scores, gsTopology, colorBy = "pvalue", plotIsolated = TRUE)
+g_Zscore <- .make_gsNetwork(Scores, gsTopology, colorBy = "robustZ", plotIsolated = TRUE, labelFun = NULL)
+g_pvalue <- .make_gsNetwork(Scores, gsTopology, colorBy = "pvalue", plotIsolated = TRUE, labelFun = NULL)
 
 test_that("make_gsNetwork produces the expected outcome",{
     expect_s3_class(g_Zscore, "igraph")


### PR DESCRIPTION
I've added a function `.rm_prefix()` which is passed to most plotting functions to remove the database prefix (e.g. 'kegg.') during plot creation, which really does clean up the plots nicely, without damaging any function gene-set names in the main outputs.

By taking this strategy, people could also write their own function to manipulate the node labels however they choose (e.g. `my_fun <- function(x) str_replace(x, "kegg\\.(.+)", "\\1\n[KEGG]")`), or whatever else they want to do. 